### PR TITLE
Fix bug format

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,9 +1,9 @@
 # Requires additional channels:
-#   conda build --python=2.7 -c insilichem -c bioconda -c conda-forge -c omnia -c "$CONDA_PREFIX/conda-bld/" .
+#   conda build --python=2.7 -c omnia -c conda-forge -c bioconda -c josan_bcn "$CONDA_PREFIX/conda-bld/" .
 
 package:
   name: gpathfinder
-  version: 1.2.0
+  version: 1.2.1
 
 about:
   home: https://github.com/insilichem/gpathfinder
@@ -42,7 +42,7 @@ requirements:
     - smina 2017.11.*
     # InsiliChem channel
     - autodocktools-prepare 1.5.7.*
-    - prody 1.8.*
+    - prody 1.10.*
 
 test:
   imports:

--- a/gpath/__init__.py
+++ b/gpath/__init__.py
@@ -63,4 +63,4 @@ __url__ = 'https://github.com/insilichem/gpathfinder'
 __title__ = 'GPathFinder'
 __description__ = ('Identification of ligand binding pathways \
                     by a multi-objective genetic algorithm')
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/gpath/algorithms.py
+++ b/gpath/algorithms.py
@@ -271,6 +271,7 @@ def construct_path_summary(population, cfg):
                     summary[filename][j]['z'] = gene.allele['positions'][j][2][-1]
                     for sc in gene.scores[j].keys():
                         summary[filename][j][sc] = gene.scores[j][sc]
+                    summary[filename][j]['coord_residues'] = gene.allele['coord_residues'][j]
     return summary
 
 def dump_population(population, cfg, subdir=None):
@@ -308,12 +309,8 @@ def dump_population(population, cfg, subdir=None):
 
             sf_writer.writerow(['Path','Frame'] + header_keys)
             for path in paths:
-                average_values = [0.0 for k in header_keys[:-3]] #only scores are averaged, not coords
                 for i, frame in enumerate(summary[path]):
                     values_frame = [path, '{:03d}'.format(i)] + [frame[k] for k in header_keys]
-                    average_values = [sum(x) for x in zip(values_frame[2:-3], average_values)]
                     sf_writer.writerow(values_frame)
-                average_values = [x / (i+1) for x in average_values]
-                sf_writer.writerow([path, 'Average'] + average_values + ['', '', ''])
     except:
         pass


### PR DESCRIPTION
Bug fix: problems with the format of some .mol2 files, that produced an error like "ValueError: invalid literal for int() with base 10:" when saving the results of GPathFinder. Thanks to Manish K. from the Nagoya University for reporting it.